### PR TITLE
Update subscription id for rpc

### DIFF
--- a/src/rpc.js
+++ b/src/rpc.js
@@ -117,15 +117,13 @@ class Client extends EventEmitter {
         }
 
         // events get passed to listener
-        this.on(id + '#event', (err, res) => {
-          if (err) return self.emit('error', err)
-          listener(res.data.value)
-        })
-
-        // promise resolves on successful subscription or error
-        this.on(id, (err) => {
-          if (err) return reject(err)
-          resolve()
+        this.on(id, (err, res) => {
+          if (err) {
+            reject(err)
+            return self.emit('error', err)
+          }
+          if (res.data) listener(res.data.value)
+          resolve(res)
         })
       } else {
         // response goes to promise

--- a/test/rpc.js
+++ b/test/rpc.js
@@ -137,10 +137,10 @@ test('ws subscription', async (t) => {
     res(null, {})
     res(null,
       { data: { value: 'foo' } },
-      `${req.id}#event`)
+      req.id)
     res(null,
       { data: { value: 'bar' } },
-      `${req.id}#event`)
+      req.id)
   })
   let rpc = RpcClient(`ws://localhost:${port}`)
   await new Promise((resolve) => {


### PR DESCRIPTION
In its last update (0.33) tendermint broke the events' ids https://github.com/tendermint/tendermint/blob/v0.33/CHANGELOG.md#breaking-changes
> [rpc] #4141 Remove #event suffix from the ID in event responses. {"jsonrpc": "2.0", "id": 0, "result": ...}

Because of that the ws rpc client is not receiving any events.

This fixes the issue. I was unable to run the tests correctly before and also after the fix so I hope the fix is enough.