### PR TITLE
Add block_by_hash method

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The following RPC methods are available:
 - blockchain
 - genesis
 - block
+- blockByHash
 - validators
 - dumpConsensusState
 - broadcastTxCommit

--- a/src/methods.js
+++ b/src/methods.js
@@ -13,6 +13,7 @@ module.exports = [
   'genesis',
   'health',
   'block',
+  'block_by_hash',
   'block_results',
   'blockchain',
   'validators',


### PR DESCRIPTION
Due to [tendermint v0.33](https://github.com/tendermint/tendermint/blob/v0.33/rpc/swagger/swagger.yaml) has block_by_hash method.